### PR TITLE
Fix broken access control across the API

### DIFF
--- a/backend/backend_project/backend_app/serializers.py
+++ b/backend/backend_project/backend_app/serializers.py
@@ -13,6 +13,7 @@ class CartSerializer(serializers.ModelSerializer):
     class Meta:
         model = Cart
         fields = ["id", "user_id", "cart_item", "image_url", "price"]
+        read_only_fields = ["user_id"]
 
 
 class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
@@ -38,12 +39,14 @@ class ListingSerializer(serializers.ModelSerializer):
             "description",
             "image_url",
         ]
+        read_only_fields = ["user", "username"]
 
 
 class ProfileSerializer(serializers.ModelSerializer):
     class Meta:
         model = Profile
         fields = ["id", "user_id", "bio", "address", "birthdate"]
+        read_only_fields = ["user_id"]
         lookup_field = "user_id"
 
 

--- a/backend/backend_project/backend_app/views.py
+++ b/backend/backend_project/backend_app/views.py
@@ -33,16 +33,35 @@ from rest_framework.exceptions import ValidationError
 # Create your views here.
 
 
+class IsOwnerOrReadOnly(permissions.BasePermission):
+    """Object-level permission: only the owner may modify; reads are open."""
+
+    def has_object_permission(self, request, view, obj):
+        if request.method in permissions.SAFE_METHODS:
+            return True
+        return obj.user_id == request.user.id
+
+
 class CartViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
-    queryset = Cart.objects.all()
+    queryset = Cart.objects.all()  # used only for router basename; see get_queryset
     serializer_class = CartSerializer
     lookup_field = "user_id"
     # parser_classes = JSONParser
 
+    def get_queryset(self):
+        return Cart.objects.filter(user_id=self.request.user)
+
+    def perform_create(self, serializer):
+        serializer.save(user_id=self.request.user)
+
+
 class CartDeleteViewSet(generics.DestroyAPIView):
-    queryset = Cart.objects.all()
+    permission_classes = [IsAuthenticated]
     serializer_class = CartSerializer
+
+    def get_queryset(self):
+        return Cart.objects.filter(user_id=self.request.user)
 
 
 
@@ -72,7 +91,7 @@ def check_image_moderation(image_file):
         )
 
 class ListingViewSet(viewsets.ModelViewSet):
-    permisssion_classes = [IsAuthenticatedOrReadOnly]
+    permission_classes = [IsAuthenticatedOrReadOnly, IsOwnerOrReadOnly]
     queryset = Listing.objects.all()
     serializer_class = ListingSerializer
     parser_classes = (MultiPartParser, FormParser)
@@ -83,7 +102,9 @@ class ListingViewSet(viewsets.ModelViewSet):
         image = self.request.FILES.get('image_url')
         if image:
             check_image_moderation(image)
-        serializer.save()
+        serializer.save(
+            user=self.request.user, username=self.request.user.username
+        )
 
     def perform_update(self, serializer):
         image = self.request.FILES.get('image_url')
@@ -104,10 +125,14 @@ class RegisterView(APIView):
 
 
 class ProfileViewSet(viewsets.ModelViewSet):
-    queryset = Profile.objects.all()
+    permission_classes = [IsAuthenticated]
+    queryset = Profile.objects.all()  # used only for router basename; see get_queryset
     serializer_class = ProfileSerializer
     lookup_field = "user_id"
     lookup_url_kwarg = "user_id"
+
+    def get_queryset(self):
+        return Profile.objects.filter(user=self.request.user)
 
     def perform_create(self, serializer):
         serializer.save(user=self.request.user)

--- a/final_project_frontend/src/components/ProfileForm.jsx
+++ b/final_project_frontend/src/components/ProfileForm.jsx
@@ -24,7 +24,11 @@ export default function ProfileDetail() {
       const apiUrl = `https://finalproject-production-bb8b.up.railway.app/profile/${localStorage.getItem(
         "userId"
       )}/`;
-      const response = await fetch(apiUrl);
+      const response = await fetch(apiUrl, {
+        headers: {
+          Authorization: `Bearer ${auth}`,
+        },
+      });
       const data = await response.json();
       setProfileDetail(data);
       // console.log(data);


### PR DESCRIPTION
The DRF default permission was AllowAny (DEFAULT_PERMISSION_CLASSES commented out), and a typo'd `permisssion_classes` on ListingViewSet meant the intended IsAuthenticatedOrReadOnly was never applied. Combined with unfiltered `objects.all()` querysets and writable owner fields, this let anyone (often unauthenticated) read or modify other users' data.

- Listings: fix the permission_classes typo; add IsOwnerOrReadOnly so only the owner can edit/delete; make user/username read-only and set them server-side from request.user (kills ownership spoofing).
- Cart: require auth on CartDeleteViewSet; scope both cart views' querysets to request.user (kills IDOR + anonymous deletion); make user_id read-only and set it server-side.
- Profile: require auth; scope queryset to request.user (kills PII read and cross-user overwrite); make user_id read-only.
- Frontend: send the JWT on the profile GET, which is now protected.

No model changes, so no migration. `manage.py check` passes.