### PR TITLE
Centralize frontend API base URL into config + env

### DIFF
--- a/final_project_frontend/.env.development
+++ b/final_project_frontend/.env.development
@@ -1,0 +1,3 @@
+# Loaded automatically by `npm run dev` (Vite). Points the dev UI at a local
+# backend so you can test against a local Django server + local database.
+VITE_API_BASE_URL=http://127.0.0.1:8000

--- a/final_project_frontend/.env.example
+++ b/final_project_frontend/.env.example
@@ -1,0 +1,6 @@
+# Base URL of the Django API.
+#
+# Local dev uses .env.development (http://127.0.0.1:8000) automatically.
+# For production, set this in your deploy provider (e.g. Netlify env vars).
+# If unset, the app falls back to the production URL defined in src/config.js.
+VITE_API_BASE_URL=https://finalproject-production-bb8b.up.railway.app

--- a/final_project_frontend/src/components/CartDetail.jsx
+++ b/final_project_frontend/src/components/CartDetail.jsx
@@ -1,3 +1,4 @@
+import { API_BASE_URL } from "../config";
 import React, { useState, useEffect } from "react";
 import { useLocation } from "react-router-dom";
 import Button from "@mui/material/Button";
@@ -29,7 +30,7 @@ export default function CartDetail() {
 
   const getCart = async () => {
     try {
-      const apiUrl = "https://finalproject-production-bb8b.up.railway.app/cart/";
+      const apiUrl = `${API_BASE_URL}/cart/`;
       const response = await fetch(apiUrl, {
         method: "GET",
         headers: {
@@ -52,7 +53,7 @@ export default function CartDetail() {
   };
 
   const handleDelete = async (id) => {
-    const apiUrl = `https://finalproject-production-bb8b.up.railway.app/cart/item/${id}/`;
+    const apiUrl = `${API_BASE_URL}/cart/item/${id}/`;
     try {
       const response = await fetch(apiUrl, {
         method: "DELETE",

--- a/final_project_frontend/src/components/DisplayListings.jsx
+++ b/final_project_frontend/src/components/DisplayListings.jsx
@@ -1,3 +1,4 @@
+import { API_BASE_URL } from "../config";
 import React, { useState, useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
 import CircularProgress from "@mui/material/CircularProgress";
@@ -14,7 +15,7 @@ export default function DisplayListings() {
 
   const getInfo = async () => {
     try {
-      const apiUrl = "https://finalproject-production-bb8b.up.railway.app/listing/";
+      const apiUrl = `${API_BASE_URL}/listing/`;
       const response = await fetch(apiUrl);
 
       if (!response.ok) {

--- a/final_project_frontend/src/components/DisplayUserListings.jsx
+++ b/final_project_frontend/src/components/DisplayUserListings.jsx
@@ -1,3 +1,4 @@
+import { API_BASE_URL } from "../config";
 import { CardContainer, NoDataDiv } from "./GlobalStyles/StyleCard";
 import { useState, useEffect } from "react";
 import React from "react";
@@ -16,7 +17,7 @@ export default function DisplayUserListings() {
   const getInfo = async () => {
     // console.log("here");
     try {
-      const apiUrl = "https://finalproject-production-bb8b.up.railway.app/listing/";
+      const apiUrl = `${API_BASE_URL}/listing/`;
       const response = await fetch(apiUrl);
       const data = await response.json();
       setListingData(data);

--- a/final_project_frontend/src/components/EditListing.jsx
+++ b/final_project_frontend/src/components/EditListing.jsx
@@ -1,3 +1,4 @@
+import { API_BASE_URL } from "../config";
 import { useEffect, useRef, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 // import { Button } from "../components/GlobalStyles/StyleUtility";
@@ -21,7 +22,7 @@ export default function EditListing() {
 
   const getIndividualListing = async () => {
     try {
-      const apiUrl = `https://finalproject-production-bb8b.up.railway.app/listing/${id}/`;
+      const apiUrl = `${API_BASE_URL}/listing/${id}/`;
       const response = await fetch(apiUrl);
       const data = await response.json();
       setListingDetail(data);
@@ -41,7 +42,7 @@ export default function EditListing() {
 const handleSubmit = async (e) => {
   e.preventDefault();
   const formData = new FormData(updateForm.current);
-  const url = `https://finalproject-production-bb8b.up.railway.app/listing/${id}/`;
+  const url = `${API_BASE_URL}/listing/${id}/`;
   const data = await fetch(url, {
     method: "PUT",
     headers: {
@@ -54,7 +55,7 @@ const handleSubmit = async (e) => {
 };
 
   const handleDelete = async () => {
-    const apiUrl = `https://finalproject-production-bb8b.up.railway.app/listing/${id}/`;
+    const apiUrl = `${API_BASE_URL}/listing/${id}/`;
     try {
       const response = await fetch(apiUrl, {
         method: "DELETE",

--- a/final_project_frontend/src/components/ListingDetail.jsx
+++ b/final_project_frontend/src/components/ListingDetail.jsx
@@ -1,3 +1,4 @@
+import { API_BASE_URL } from "../config";
 import React, { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import Button from "@mui/material/Button";
@@ -30,7 +31,7 @@ export default function ListingDetail() {
 
   const getIndividualListing = async () => {
     try {
-      const apiUrl = `https://finalproject-production-bb8b.up.railway.app/listing/${id}/`;
+      const apiUrl = `${API_BASE_URL}/listing/${id}/`;
       const response = await fetch(apiUrl);
       const data = await response.json();
       // console.log(data);
@@ -52,7 +53,7 @@ export default function ListingDetail() {
     e.preventDefault();
     setAlert(true);
 
-    const url = `https://finalproject-production-bb8b.up.railway.app/cart/`;
+    const url = `${API_BASE_URL}/cart/`;
     try {
       const response = await fetch(url, {
         method: "POST",

--- a/final_project_frontend/src/components/ListingForm.jsx
+++ b/final_project_frontend/src/components/ListingForm.jsx
@@ -1,3 +1,4 @@
+import { API_BASE_URL } from "../config";
 import { useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 // import { Button } from "../components/GlobalStyles/StyleUtility";
@@ -16,7 +17,7 @@ export default function ListingForm() {
     e.preventDefault();
     const formData = new FormData(updateForm.current);
 
-    const url = "https://finalproject-production-bb8b.up.railway.app/listing/";
+    const url = `${API_BASE_URL}/listing/`;
     const data = await fetch(url, {
       method: "POST",
       headers: {

--- a/final_project_frontend/src/components/LogOut.jsx
+++ b/final_project_frontend/src/components/LogOut.jsx
@@ -1,3 +1,4 @@
+import { API_BASE_URL } from "../config";
 import React, { useEffect } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useAuth } from "../AuthContext";
@@ -10,7 +11,7 @@ export default function LogoutPage() {
   console.log(setIsAuth());
 
   const performLogout = async () => {
-    const url = "https://finalproject-production-bb8b.up.railway.app/logout/";
+    const url = `${API_BASE_URL}/logout/`;
     const refresh_token = localStorage.getItem("refresh_token");
     const access_token = localStorage.getItem("access_token");
 

--- a/final_project_frontend/src/components/LoginForm.jsx
+++ b/final_project_frontend/src/components/LoginForm.jsx
@@ -1,3 +1,4 @@
+import { API_BASE_URL } from "../config";
 import { useState } from "react";
 import { useAuth } from "../AuthContext";
 import { useNavigate } from "react-router";
@@ -25,7 +26,7 @@ export default function LoginForm() {
       username,
       password,
     };
-    const url = "https://finalproject-production-bb8b.up.railway.app/token/";
+    const url = `${API_BASE_URL}/token/`;
     const data = await fetch(url, {
       method: "POST",
       headers: {

--- a/final_project_frontend/src/components/ProfileForm.jsx
+++ b/final_project_frontend/src/components/ProfileForm.jsx
@@ -1,3 +1,4 @@
+import { API_BASE_URL } from "../config";
 import React from "react";
 import { useState, useEffect, useRef } from "react";
 import { useRevalidator, useParams, useNavigate } from "react-router-dom";
@@ -21,7 +22,7 @@ export default function ProfileDetail() {
 
   const getIndividualProfile = async () => {
     try {
-      const apiUrl = `https://finalproject-production-bb8b.up.railway.app/profile/${localStorage.getItem(
+      const apiUrl = `${API_BASE_URL}/profile/${localStorage.getItem(
         "userId"
       )}/`;
       const response = await fetch(apiUrl, {
@@ -61,7 +62,7 @@ export default function ProfileDetail() {
 
   const handlePost = async (formData) => {
     // const formData = new FormData(updateForm.current);
-    const apiUrl = `https://finalproject-production-bb8b.up.railway.app/profile/`;
+    const apiUrl = `${API_BASE_URL}/profile/`;
     const data = await fetch(apiUrl, {
       method: "POST",
       headers: {
@@ -73,7 +74,7 @@ export default function ProfileDetail() {
   };
 
   const handlePut = async (formData) => {
-    const apiUrl = `https://finalproject-production-bb8b.up.railway.app/profile/${localStorage.getItem(
+    const apiUrl = `${API_BASE_URL}/profile/${localStorage.getItem(
       "userId"
     )}/`;
     const data = await fetch(apiUrl, {

--- a/final_project_frontend/src/components/RegisterForm.jsx
+++ b/final_project_frontend/src/components/RegisterForm.jsx
@@ -1,3 +1,4 @@
+import { API_BASE_URL } from "../config";
 import { useRef } from "react";
 import React from "react";
 import { Form } from "./GlobalStyles/StyleUtility";
@@ -15,7 +16,7 @@ export default function RegisterForm() {
     e.preventDefault();
     const formData = new FormData(updateForm.current);
 
-    const url = "https://finalproject-production-bb8b.up.railway.app/register/";
+    const url = `${API_BASE_URL}/register/`;
     const data = await fetch(url, {
       method: "POST",
       headers: {

--- a/final_project_frontend/src/components/SearchFeature.jsx
+++ b/final_project_frontend/src/components/SearchFeature.jsx
@@ -1,3 +1,4 @@
+import { API_BASE_URL } from "../config";
 import React, { useEffect } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { useState } from "react";
@@ -15,7 +16,7 @@ export default function Search() {
   const navigate = useNavigate();
 
   async function getSearch() {
-    const url = `https://finalproject-production-bb8b.up.railway.app/listing/?search=${params.search}`;
+    const url = `${API_BASE_URL}/listing/?search=${params.search}`;
     try {
       const response = await fetch(url);
       const result = await response.json();

--- a/final_project_frontend/src/config.js
+++ b/final_project_frontend/src/config.js
@@ -1,0 +1,11 @@
+// Central API base URL for the backend.
+//
+// Override per environment with the VITE_API_BASE_URL env var:
+//   - local dev: .env.development points this at http://127.0.0.1:8000
+//   - production: set VITE_API_BASE_URL in the deploy provider (e.g. Netlify)
+//
+// Falls back to the production URL so existing deploys keep working even if
+// the env var is not set.
+export const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL ||
+  "https://finalproject-production-bb8b.up.railway.app";


### PR DESCRIPTION
Every component hardcoded the production API URL (17 occurrences across 11 files), so the dev UI always talked to production and local testing was impossible without editing each file.

- Add src/config.js exporting API_BASE_URL from VITE_API_BASE_URL, with the production URL as a fallback so existing deploys need no config.
- Replace all hardcoded URLs with API_BASE_URL (converting plain-string fetch URLs to template literals).
- .env.development points `npm run dev` at http://127.0.0.1:8000.
- .env.example documents the variable for production (e.g. Netlify).

Verified: `npm run build` succeeds; the production bundle resolves to the prod URL (localhost does not leak in).