### PR TITLE
fix: align cart and listing-detail image/condition styling with card …

### DIFF
--- a/final_project_frontend/src/components/GlobalStyles/StyleCart.jsx
+++ b/final_project_frontend/src/components/GlobalStyles/StyleCart.jsx
@@ -43,10 +43,11 @@ export const CartButton = styled.div`
 
 export const CartImg = styled.div`
   width: 125px;
-  height: 125px;
+  aspect-ratio: 1 / 1;
   flex-shrink: 0;
   display: flex;
-  
+  overflow: hidden;
+
   img {
     object-fit: cover;
     width: 100%;

--- a/final_project_frontend/src/components/ListingDetail.jsx
+++ b/final_project_frontend/src/components/ListingDetail.jsx
@@ -6,6 +6,7 @@ import CircularProgress from "@mui/material/CircularProgress";
 import Alert from "@mui/material/Alert";
 import { ProgressDiv } from "./GlobalStyles/StyleUtility";
 import conditionColor from "../utils/conditionColor";
+import { ConditionDot } from "./GlobalStyles/StyleCard";
 
 import {
   DetailDescription,
@@ -119,16 +120,7 @@ export default function ListingDetail() {
                     <div className="cell condition">
                       <p className="label">Condition</p>
                       <div className="condition-row">
-                        <span
-                          style={{
-                            width: 8,
-                            height: 8,
-                            borderRadius: "50%",
-                            background: conditionColor(listingDetail.condition),
-                            display: "inline-block",
-                            flexShrink: 0,
-                          }}
-                        />
+                        <ConditionDot color={conditionColor(listingDetail.condition)} />
                         <p className="value">{listingDetail.condition}</p>
                       </div>
                     </div>


### PR DESCRIPTION
…pattern

- CartImg: swap fixed height:125px for aspect-ratio:1/1 + overflow:hidden, matching the aspect-ratio pattern used by Card/DetailImage elsewhere
- ListingDetail: reuse the shared ConditionDot styled component instead of a duplicated inline-style span, so it can't drift from the other cards